### PR TITLE
Always NULL terminate stringSubstitute result

### DIFF
--- a/addpath.c
+++ b/addpath.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <assert.h>
 
 extern const char *rtems_bsdnet_domain_name;
 
@@ -174,6 +175,8 @@ stringSubstitute(const char *p, const char * const *s, int ns)
 			}
 		}
 	}
+	*dd++ = 0;
+	assert(dd == rval + l + 1);
 	return rval;
 }
 


### PR DESCRIPTION
I was noticing that `nfsMount` was failing with garbage chars at the end of the mount string. 

Looking into it, `stringSubstitute` was already fixed in 4.10.2 GeSys, so I'm just backporting that change. Might as well kill two birds with one stone if we do another 4.9.4 patch. 