### PR TITLE
Add workaround for GCC 4.8.X bug with weak aliased symbols

### DIFF
--- a/cexp-txtregion.c
+++ b/cexp-txtregion.c
@@ -6,8 +6,13 @@
 
 uintptr_t BSP_sbrk_policy = -1; /*-1;*/
 
-#ifdef RTEMS_CEXP_TEXT_REGION_SIZE
+#if defined(RTEMS_CEXP_TEXT_REGION_SIZE) && RTEMS_CEXP_TEXT_REGION_SIZE > 0
 /* hopefully goes into .bss */
 char cexpTextRegion[RTEMS_CEXP_TEXT_REGION_SIZE] = {0};
 unsigned long cexpTextRegionSize = RTEMS_CEXP_TEXT_REGION_SIZE;
+#else
+/** JL: workaround for GCC 4.8.5 bug: we must define cexpTextRegionSize here, otherwise the weak alias cexpTextRegionSize in cexpsh will be used
+ * The symbol that cexpTextRegionSize is aliased to ends up in .rodata due to an optimization bug. This all works fine with -O0
+ */
+unsigned long cexpTextRegionSize = 0;
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -361,6 +361,7 @@ case "$rtems_bsp" in
 		RTEMS_CEXP_TEXT_REGION_SIZE=0x01000000
 	;;
 	*)
+		RTEMS_CEXP_TEXT_REGION_SIZE=0x0
 	;;
 esac
 case "$target_cpu" in


### PR DESCRIPTION
Upstreamed from [SLAC's rtems-gesys fork](https://github.com/slaclab/rtems-gesys/commit/0a788d7da843b6564bed5b9fc24a44dc1675a771)

Workaround for a GCC 4.8.X bug where GCC will emit the weak aliased `cexpTextRegionSize` into a `.rodata` section, even though it's non-const. 

This only affected the SVGM target because RTEMS_CEXP_TEXT_REGION_SIZE was previously not defined there.

Demonstration on GCC 4.8.5: https://godbolt.org/z/5YYez3Kv4
```asm
        .section        .rodata
        ...
_test:
        .long   1023
```

Works fine on GCC 11: https://godbolt.org/z/aEP6Wr9jz
```asm
        .section        ".data"
        ...
_test:
        .long   1023
```